### PR TITLE
Apply MIT license

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Jason Jackson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ That's all! Test out everything by doing a few builds and watch Slack for messag
 #### Notes:
 * The target framework for the plugin DLL is set to .NET Framework 3.5. When it was .NET 4/4.5, CCNet errored to the Event Viewer with "This assembly is built by a runtime newer than the currently loaded runtime and cannot be loaded." This may be different for different versions of CCNet (I'm on 1.6)
 * The CCNet assemblies included and referenced are from v1.6. If you have another version of CCNet, you can try putting its assemblies into the lib folder and updating the project references. The 3 DLLs you'll need to copy from the CruiseControl.NET\server folder are: NetReflector.dll, ThoughtWorks.CruiseControl.Core.dll and ThoughtWorks.CruiseControl.Remote.dll.
+
+#### License:
+See license.txt for licensing information.


### PR DESCRIPTION
It does not appear the CCNetSlackPublisher tool has any specified license. As such I am unable to legally, or in good conscience, use or contribute to your very helpful CCNetSlackPublisher library without an official license applied. 

In the off chance that not applying a license was an oversight I have generated this pull request to apply the MIT license. If the MIT license is not to your liking please choose another license (or none at all).

If your decision to not apply a license was a conscious decision I apologize for being so bold in suggesting one.

V/r,
Ryan
